### PR TITLE
Add LPO number display in invoice PDFs and statements

### DIFF
--- a/src/utils/jsPdfGenerator.ts
+++ b/src/utils/jsPdfGenerator.ts
@@ -203,6 +203,14 @@ export const generateJsPDF = (data: DocumentData) => {
     detailsY += 5;
   }
 
+  if (data.lpo_number) {
+    doc.setTextColor(100, 100, 100);
+    doc.text('LPO No.:', detailsX, detailsY);
+    doc.setTextColor(0, 0, 0);
+    doc.text(sanitizeText(data.lpo_number), detailsX + 20, detailsY);
+    detailsY += 5;
+  }
+
   doc.setTextColor(100, 100, 100);
   doc.text('Amount:', detailsX, detailsY);
   doc.setTextColor(75, 33, 182);

--- a/src/utils/jsPdfGenerator.ts
+++ b/src/utils/jsPdfGenerator.ts
@@ -1,5 +1,6 @@
 import jsPDF from 'jspdf';
 import autoTable from 'jspdf-autotable';
+import { sanitizeText } from './textSanitizer';
 
 interface DocumentData {
   type: 'quotation' | 'invoice' | 'remittance' | 'proforma' | 'delivery' | 'statement' | 'receipt' | 'lpo';
@@ -213,7 +214,7 @@ export const generateJsPDF = (data: DocumentData) => {
   // Items Table
   if (data.items && data.items.length > 0) {
     const tableData = data.items.map(item => [
-      item.description,
+      sanitizeText(item.description),
       item.quantity.toString(),
       formatCurrency(item.unit_price),
       item.tax_percentage ? `${item.tax_percentage}%` : '0%',
@@ -341,7 +342,7 @@ export const generateJsPDF = (data: DocumentData) => {
     const availableAreaHeight = pageHeight - topY - titleGap - dynamicFooterHeight - areaBottomPadding;
 
     // Prepare terms text (fallback to empty string if none)
-    const termsText = data.terms_and_conditions || '';
+    const termsText = sanitizeText(data.terms_and_conditions || '');
 
     // Accurate fit calculation: convert pt -> mm
     const PT_TO_MM = 0.352777778;

--- a/src/utils/pdfGenerator.ts
+++ b/src/utils/pdfGenerator.ts
@@ -122,6 +122,7 @@ const analyzeColumns = (items: DocumentData['items']) => {
 const buildDocumentHTML = (data: DocumentData) => {
   const company = data.company || DEFAULT_COMPANY;
   const visibleColumns = analyzeColumns(data.items);
+  const hasStatementLPO = data.type === 'statement' && Array.isArray(data.items) && data.items.some((i: any) => i && (i as any).lpo_number);
 
   const formatCurrency = (amount: number) => new Intl.NumberFormat('en-KE', {
     style: 'currency', currency: 'KES', minimumFractionDigits: 2, maximumFractionDigits: 2
@@ -272,6 +273,7 @@ const buildDocumentHTML = (data: DocumentData) => {
                 <tr><td class="label">${data.type === 'lpo' ? 'Order Date' : 'Date'}:</td><td class="value">${formatDate(data.date)}</td></tr>
                 ${data.due_date ? `<tr><td class="label">${data.type === 'lpo' ? 'Expected Delivery' : 'Due Date'}:</td><td class="value">${formatDate(data.due_date)}</td></tr>` : ''}
                 ${data.valid_until ? `<tr><td class="label">Valid Until:</td><td class="value">${formatDate(data.valid_until)}</td></tr>` : ''}
+                ${data.lpo_number ? `<tr><td class="label">LPO No.:</td><td class="value">${sanitizeAndEscape(data.lpo_number)}</td></tr>` : ''}
                 <tr><td class="label">${data.type === 'receipt' ? 'Amount Paid' : data.type === 'remittance' ? 'Total Payment' : data.type === 'lpo' ? 'Order Total' : 'Amount'}:</td><td class="value" style="font-weight: bold; color: #111827;">${formatCurrency(data.total_amount)}</td></tr>
               </table>
             </div>
@@ -448,6 +450,7 @@ export const generatePDF = (data: DocumentData) => {
 
   // Analyze which columns have values
   const visibleColumns = analyzeColumns(data.items);
+  const hasStatementLPO = data.type === 'statement' && Array.isArray(data.items) && data.items.some((i: any) => i && (i as any).lpo_number);
   const formatCurrency = (amount: number) => {
     return new Intl.NumberFormat('en-KE', {
       style: 'currency',
@@ -983,6 +986,12 @@ export const generatePDF = (data: DocumentData) => {
                       <td class="value">${formatDate(data.valid_until)}</td>
                     </tr>
                     ` : ''}
+                    ${data.lpo_number ? `
+                    <tr>
+                      <td class="label">LPO No.:</td>
+                      <td class="value">${sanitizeAndEscape(data.lpo_number)}</td>
+                    </tr>
+                    ` : ''}
                     <tr>
                       <td class="label">${data.type === 'receipt' ? 'Amount Paid' : data.type === 'remittance' ? 'Total Payment' : data.type === 'lpo' ? 'Order Total' : 'Amount'}:</td>
                       <td class="value" style="font-weight: bold; color: #111827;">${formatCurrency(data.total_amount)}</td>
@@ -1078,6 +1087,7 @@ export const generatePDF = (data: DocumentData) => {
                 <th style="width: 12%;">Date</th>
                 <th style="width: 25%;">Description</th>
                 <th style="width: 15%;">Reference</th>
+                ${hasStatementLPO ? '<th style="width: 12%;">LPO No.</th>' : ''}
                 <th style="width: 12%;">Debit</th>
                 <th style="width: 12%;">Credit</th>
                 <th style="width: 12%;">Balance</th>
@@ -1109,6 +1119,7 @@ export const generatePDF = (data: DocumentData) => {
                   <td>${formatDate((item as any).transaction_date)}</td>
                   <td class="description-cell">${sanitizeAndEscape(item.description)}</td>
                   <td>${(item as any).reference}</td>
+                  ${hasStatementLPO ? `<td>${sanitizeAndEscape((item as any).lpo_number || '')}</td>` : ''}
                   <td class="amount-cell">${(item as any).debit > 0 ? formatCurrency((item as any).debit) : ''}</td>
                   <td class="amount-cell">${(item as any).credit > 0 ? formatCurrency((item as any).credit) : ''}</td>
                   <td class="amount-cell">${formatCurrency(item.line_total)}</td>
@@ -1635,7 +1646,8 @@ export const generateCustomerStatementPDF = async (customer: any, invoices: any[
       description: `Invoice ${inv.invoice_number}`,
       debit: inv.total_amount || 0,
       credit: 0,
-      due_date: inv.due_date
+      due_date: inv.due_date,
+      lpo_number: inv.lpo_number
     })),
     // Add all payments as credits
     ...payments.map(pay => ({
@@ -1672,7 +1684,8 @@ export const generateCustomerStatementPDF = async (customer: any, invoices: any[
       debit: Number(transaction.debit || 0),
       credit: Number(transaction.credit || 0),
       due_date: transaction.due_date,
-      days_overdue: transaction.due_date ? Math.max(0, Math.floor((today.getTime() - new Date(transaction.due_date).getTime()) / (1000 * 60 * 60 * 24))) : 0
+      days_overdue: transaction.due_date ? Math.max(0, Math.floor((today.getTime() - new Date(transaction.due_date).getTime()) / (1000 * 60 * 60 * 24))) : 0,
+      lpo_number: (transaction as any).lpo_number
     };
   });
 

--- a/src/utils/pdfGenerator.ts
+++ b/src/utils/pdfGenerator.ts
@@ -1,5 +1,6 @@
 import { jsPDF } from 'jspdf';
 import html2canvas from 'html2canvas';
+import { sanitizeAndEscape } from './textSanitizer';
 
 // PDF Generation utility using HTML to print/PDF conversion
 // Since we don't have jsPDF installed, I'll create a simple HTML-to-print function
@@ -347,7 +348,7 @@ const buildDocumentHTML = (data: DocumentData) => {
             <tr>
               ${data.type === 'statement' ? `
                 <td>${formatDate((item as any).transaction_date)}</td>
-                <td class="description-cell">${item.description}</td>
+                <td class="description-cell">${sanitizeAndEscape(item.description)}</td>
                 <td>${(item as any).reference}</td>
                 <td class="amount-cell">${(item as any).debit > 0 ? formatCurrency((item as any).debit) : ''}</td>
                 <td class="amount-cell">${(item as any).credit > 0 ? formatCurrency((item as any).credit) : ''}</td>
@@ -361,7 +362,7 @@ const buildDocumentHTML = (data: DocumentData) => {
                 <td class="amount-cell" style="font-weight: bold;">${formatCurrency(item.line_total)}</td>
               ` : `
                 <td>${index + 1}</td>
-                <td class="description-cell">${item.description}</td>
+                <td class="description-cell">${sanitizeAndEscape(item.description)}</td>
                 ${data.type === 'delivery' ? `
                   <td>${(item as any).quantity_ordered || item.quantity}</td>
                   <td style="font-weight: bold; color: ${(item as any).quantity_delivered >= (item as any).quantity_ordered ? '#10B981' : '#F59E0B'};">${(item as any).quantity_delivered || item.quantity}</td>
@@ -421,7 +422,7 @@ const buildDocumentHTML = (data: DocumentData) => {
     <div class="invoice-terms-section" style="page-break-before: always;">
       <div class="invoice-terms">
         <div class="section-subtitle">Terms & Conditions</div>
-        <div class="terms-content">${data.terms_and_conditions}</div>
+        <div class="terms-content">${sanitizeAndEscape(data.terms_and_conditions || '')}</div>
       </div>
     </div>` : ''}
 
@@ -1106,7 +1107,7 @@ export const generatePDF = (data: DocumentData) => {
                 <tr>
                   ${data.type === 'statement' ? `
                   <td>${formatDate((item as any).transaction_date)}</td>
-                  <td class="description-cell">${item.description}</td>
+                  <td class="description-cell">${sanitizeAndEscape(item.description)}</td>
                   <td>${(item as any).reference}</td>
                   <td class="amount-cell">${(item as any).debit > 0 ? formatCurrency((item as any).debit) : ''}</td>
                   <td class="amount-cell">${(item as any).credit > 0 ? formatCurrency((item as any).credit) : ''}</td>
@@ -1120,7 +1121,7 @@ export const generatePDF = (data: DocumentData) => {
                   <td class="amount-cell" style="font-weight: bold;">${formatCurrency(item.line_total)}</td>
                   ` : `
                   <td>${index + 1}</td>
-                  <td class="description-cell">${item.description}</td>
+                  <td class="description-cell">${sanitizeAndEscape(item.description)}</td>
                   ${data.type === 'delivery' ? `
                   <td>${(item as any).quantity_ordered || item.quantity}</td>
                   <td style="font-weight: bold; color: ${(item as any).quantity_delivered >= (item as any).quantity_ordered ? '#10B981' : '#F59E0B'};">${(item as any).quantity_delivered || item.quantity}</td>
@@ -1208,7 +1209,7 @@ export const generatePDF = (data: DocumentData) => {
         <div class="invoice-terms-section" style="page-break-before: always;">
           <div class="invoice-terms">
             <div class="section-subtitle">Terms & Conditions</div>
-            <div class="terms-content">${data.terms_and_conditions}</div>
+        <div class="terms-content">${sanitizeAndEscape(data.terms_and_conditions || '')}</div>
           </div>
         </div>
         ` : ''}

--- a/src/utils/textSanitizer.ts
+++ b/src/utils/textSanitizer.ts
@@ -1,0 +1,31 @@
+export function sanitizeText(input: unknown): string {
+  if (input === null || input === undefined) return '';
+  let s = String(input);
+  // Normalize common problematic typography to ASCII equivalents
+  s = s
+    // Curly single quotes/apostrophes to straight apostrophe
+    .replace(/[\u2018\u2019\uFF07]/g, "'")
+    // Curly double quotes to straight double quote
+    .replace(/[\u201C\u201D]/g, '"')
+    // En dash / Em dash to simple hyphen
+    .replace(/[\u2013\u2014]/g, '-')
+    // Ellipsis to three dots
+    .replace(/\u2026/g, '...')
+    // Non‑breaking space to normal space
+    .replace(/\u00A0/g, ' ')
+    // Replacement character(s) often appearing from bad encoding
+    .replace(/\uFFFD+/g, "'");
+  return s;
+}
+
+export function escapeHtml(input: string): string {
+  return input
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/\"/g, '&quot;');
+}
+
+export function sanitizeAndEscape(input: unknown): string {
+  return escapeHtml(sanitizeText(input));
+}


### PR DESCRIPTION
## Purpose
Add LPO (Local Purchase Order) number display functionality to invoice PDFs and customer statements when the LPO number exists, improving document traceability and compliance with business requirements.

## Code changes
- **Created text sanitization utilities** (`textSanitizer.ts`) to handle special characters and HTML escaping for safe PDF rendering
- **Enhanced jsPDF generator** to display LPO number in document details section when available
- **Updated HTML PDF generator** to include LPO number in document metadata table
- **Modified statement generation** to show LPO numbers in statement line items with dedicated column when present
- **Applied text sanitization** across all user-input fields (descriptions, terms & conditions) to prevent rendering issues
- **Extended customer statement data structure** to include LPO number tracking for invoice transactionsTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 15`

🔗 [Edit in Builder.io](https://builder.io/app/projects/66d616941525431f9113feb0969ab0c5/pulse-space)

👀 [Preview Link](https://66d616941525431f9113feb0969ab0c5-pulse-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>66d616941525431f9113feb0969ab0c5</projectId>-->
<!--<branchName>pulse-space</branchName>-->