### PR TITLE
Add date, LPO, delivery note, invoice and amount columns

### DIFF
--- a/src/pages/reports/StatementOfAccounts.tsx
+++ b/src/pages/reports/StatementOfAccounts.tsx
@@ -26,7 +26,7 @@ import {
 } from 'lucide-react';
 import { generateCustomerStatementPDF } from '@/utils/pdfGenerator';
 import { toast } from 'sonner';
-import { useCustomers, usePayments, useCompanies } from '@/hooks/useDatabase';
+import { useCustomers, usePayments, useCompanies, useDeliveryNotes } from '@/hooks/useDatabase';
 import { useInvoicesFixed as useInvoices } from '@/hooks/useInvoicesFixed';
 
 // Helper function to compute customer statements from real data

--- a/src/pages/reports/StatementOfAccounts.tsx
+++ b/src/pages/reports/StatementOfAccounts.tsx
@@ -30,7 +30,7 @@ import { useCustomers, usePayments, useCompanies, useDeliveryNotes } from '@/hoo
 import { useInvoicesFixed as useInvoices } from '@/hooks/useInvoicesFixed';
 
 // Helper function to compute customer statements from real data
-const computeCustomerStatements = (customers: any[], invoices: any[], payments: any[]) => {
+const computeCustomerStatements = (customers: any[], invoices: any[], payments: any[], deliveryNotes: any[] = []) => {
   if (!customers || !invoices || !payments) return [];
 
   return customers.map(customer => {

--- a/src/pages/reports/StatementOfAccounts.tsx
+++ b/src/pages/reports/StatementOfAccounts.tsx
@@ -62,15 +62,23 @@ const computeCustomerStatements = (customers: any[], invoices: any[], payments: 
 
     // Build transactions array
     const allTransactions = [
-      ...customerInvoices.map(inv => ({
-        date: inv.invoice_date,
-        type: 'Invoice',
-        reference: inv.invoice_number,
-        description: `Invoice - ${inv.invoice_number}`,
-        debit: Number(inv.total_amount) || 0,
-        credit: 0,
-        balance: 0 // Will be calculated
-      })),
+      ...customerInvoices.map(inv => {
+        const dn = deliveryNotes.find((d: any) => d.invoice_id === inv.id);
+        const deliveryNoteNumber = dn?.delivery_number || dn?.delivery_note_number || '';
+        return {
+          date: inv.invoice_date,
+          type: 'Invoice',
+          reference: inv.invoice_number,
+          description: `Invoice - ${inv.invoice_number}`,
+          debit: Number(inv.total_amount) || 0,
+          credit: 0,
+          balance: 0,
+          invoice_number: inv.invoice_number,
+          lpo_number: inv.lpo_number || '',
+          delivery_note_number: deliveryNoteNumber,
+          amount: Number(inv.total_amount) || 0
+        };
+      }),
       ...customerPayments.map(pay => ({
         date: pay.payment_date,
         type: 'Payment',
@@ -78,7 +86,11 @@ const computeCustomerStatements = (customers: any[], invoices: any[], payments: 
         description: `Payment - ${pay.payment_method || 'Cash'}`,
         debit: 0,
         credit: Number(pay.amount) || 0,
-        balance: 0 // Will be calculated
+        balance: 0,
+        invoice_number: '',
+        lpo_number: '',
+        delivery_note_number: '',
+        amount: -(Number(pay.amount) || 0)
       }))
     ];
 

--- a/src/pages/reports/StatementOfAccounts.tsx
+++ b/src/pages/reports/StatementOfAccounts.tsx
@@ -441,12 +441,10 @@ const StatementOfAccounts = () => {
                         <TableHeader>
                           <TableRow>
                             <TableHead>Date</TableHead>
-                            <TableHead>Type</TableHead>
-                            <TableHead>Reference</TableHead>
-                            <TableHead>Description</TableHead>
-                            <TableHead className="text-right">Debit</TableHead>
-                            <TableHead className="text-right">Credit</TableHead>
-                            <TableHead className="text-right">Balance</TableHead>
+                            <TableHead>LPO</TableHead>
+                            <TableHead>Delivery Note</TableHead>
+                            <TableHead>Invoice No.</TableHead>
+                            <TableHead className="text-right">Amount</TableHead>
                           </TableRow>
                         </TableHeader>
                         <TableBody>
@@ -458,21 +456,11 @@ const StatementOfAccounts = () => {
                                   <span>{new Date(transaction.date).toLocaleDateString()}</span>
                                 </div>
                               </TableCell>
-                              <TableCell>
-                                <Badge variant={transaction.type === 'Payment' ? 'default' : 'secondary'}>
-                                  {transaction.type}
-                                </Badge>
-                              </TableCell>
-                              <TableCell className="font-medium">{transaction.reference}</TableCell>
-                              <TableCell>{transaction.description}</TableCell>
-                              <TableCell className="text-right text-destructive">
-                                {transaction.debit > 0 ? formatCurrency(transaction.debit) : ''}
-                              </TableCell>
-                              <TableCell className="text-right text-success">
-                                {transaction.credit > 0 ? formatCurrency(transaction.credit) : ''}
-                              </TableCell>
+                              <TableCell className="font-medium">{transaction.lpo_number || ''}</TableCell>
+                              <TableCell className="font-medium">{transaction.delivery_note_number || ''}</TableCell>
+                              <TableCell className="font-medium">{transaction.invoice_number || ''}</TableCell>
                               <TableCell className="text-right font-medium">
-                                {formatCurrency(transaction.balance)}
+                                {formatCurrency(transaction.amount ?? (transaction.debit > 0 ? transaction.debit : -transaction.credit))}
                               </TableCell>
                             </TableRow>
                           ))}

--- a/src/pages/reports/StatementOfAccounts.tsx
+++ b/src/pages/reports/StatementOfAccounts.tsx
@@ -136,9 +136,15 @@ const StatementOfAccounts = () => {
   const { data: customers } = useCustomers(currentCompany?.id);
   const { data: invoices } = useInvoices(currentCompany?.id);
   const { data: payments } = usePayments(currentCompany?.id);
+  const { data: deliveryNotes } = useDeliveryNotes(currentCompany?.id);
 
   // Compute statements from real data
-  const computedStatements = computeCustomerStatements(customers || [], invoices || [], payments || []);
+  const computedStatements = computeCustomerStatements(
+    customers || [],
+    invoices || [],
+    payments || [],
+    deliveryNotes || []
+  );
 
   const handleDownloadStatement = async (statement: any) => {
     try {


### PR DESCRIPTION
## Purpose

The user requested an audit of the Statement of Accounts with the addition of specific columns to improve data visibility. The goal was to enhance the statement by including date, LPO, delivery note, invoice number, and amount columns for better transaction tracking and reporting.

## Code changes

- **Enhanced data fetching**: Added `useDeliveryNotes` hook to fetch delivery note data
- **Updated transaction computation**: Modified `computeCustomerStatements` function to include delivery notes parameter and map delivery note numbers to invoices
- **Expanded transaction objects**: Added new fields (`invoice_number`, `lpo_number`, `delivery_note_number`, `amount`) to both invoice and payment transaction objects
- **Redesigned table structure**: Replaced the previous 7-column layout (Date, Type, Reference, Description, Debit, Credit, Balance) with a simplified 5-column layout (Date, LPO, Delivery Note, Invoice No., Amount)
- **Improved data display**: Updated table cells to show the new fields with proper formatting and fallbacks for empty valuesTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 16`

🔗 [Edit in Builder.io](https://builder.io/app/projects/66d616941525431f9113feb0969ab0c5/swoosh-studio)

👀 [Preview Link](https://66d616941525431f9113feb0969ab0c5-swoosh-studio.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>66d616941525431f9113feb0969ab0c5</projectId>-->
<!--<branchName>swoosh-studio</branchName>-->